### PR TITLE
커스텀 예외 처리 로직 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,8 @@ out/
 ### VS Code ###
 .vscode/
 
+# OS
+.DS_Store
+
 ### .env ###
 dev.env

--- a/src/main/java/com/bookmate/bookmate/common/error/ErrorResponse.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/ErrorResponse.java
@@ -1,0 +1,61 @@
+package com.bookmate.bookmate.common.error;
+
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+  private int status;
+  private String code;
+  private String message;
+  private List<String> values = new ArrayList<>();
+
+  private ErrorResponse(final int status, final ErrorCode code) {
+    this.status = status;
+    this.message = code.getMessage();
+    this.code = code.getCode();
+  }
+
+  private ErrorResponse(final int status, final ErrorCode code, final String value) {
+    this(status, code);
+    this.values = List.of(value);
+  }
+
+  private ErrorResponse(final int status, final ErrorCode code, final List<String> values) {
+    this(status, code);
+    this.values = values;
+  }
+
+  public static ErrorResponse of(final int status, final ErrorCode code,
+      final BindingResult bindingResult) {
+
+    List<String> values = bindingResult.getFieldErrors().stream()
+        .map(error ->
+            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString())
+        .collect(Collectors.toList());
+    return new ErrorResponse(status, code, values);
+  }
+
+  public static ErrorResponse of(final int status, final ErrorCode code) {
+    return new ErrorResponse(status, code);
+  }
+
+  public static ErrorResponse of(final int status, final ErrorCode code,
+      final String value) {
+    return new ErrorResponse(status, code, value);
+  }
+
+  public static ErrorResponse of(int status, MethodArgumentTypeMismatchException e) {
+    final String value = e.getValue() == null ? "" : e.getValue().toString();
+    return new ErrorResponse(status, ErrorCode.INVALID_TYPE_VALUE, value);
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,163 @@
+package com.bookmate.bookmate.common.error;
+
+import com.bookmate.bookmate.common.error.exception.BusinessException;
+import com.bookmate.bookmate.common.error.exception.DuplicateException;
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+import com.bookmate.bookmate.common.error.exception.ForbiddenException;
+import com.bookmate.bookmate.common.error.exception.NotFoundException;
+import com.bookmate.bookmate.common.error.exception.UnauthorizedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+  /**
+   * Validated 시 바인딩 에러가 존재할 때 발생
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+    log.info("Handle MethodArgumentNotValidException", e);
+
+    final int status = HttpStatus.BAD_REQUEST.value();
+    final ErrorResponse response = ErrorResponse.of(status, ErrorCode.INVALID_INPUT_VALUE,
+        e.getBindingResult());
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
+  }
+
+  /**
+   * RequestParam 타입이 맞지 않을 때 발생
+   */
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException e) {
+    log.info("Handle MethodArgumentTypeMismatchException", e);
+
+    final int status = HttpStatus.BAD_REQUEST.value();
+    final ErrorResponse response = ErrorResponse.of(status, e);
+
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * 지원하지 않는 HTTP 메서드로 요청 시
+   */
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+      HttpRequestMethodNotSupportedException e) {
+    log.info("Handle HttpRequestMethodNotSupportedException", e);
+
+    final int status = HttpStatus.METHOD_NOT_ALLOWED.value();
+    final ErrorResponse response = ErrorResponse.of(status, ErrorCode.METHOD_NOT_ALLOWED);
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
+  }
+
+  /**
+   * JSON Request Body 에서 type mismatch 가 발생할 때
+   */
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException e) {
+    log.info("Handle HttpMessageNotReadableException", e);
+
+    final int status = HttpStatus.BAD_REQUEST.value();
+    final ErrorResponse response = ErrorResponse.of(status, ErrorCode.INVALID_TYPE_VALUE);
+
+    return new ResponseEntity<>(response,
+        HttpStatus.valueOf(status));
+  }
+
+  /**
+   * 서버에서 발생하는 모든 예상치 못한 예외 처리
+   */
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error("Handle Exception", e);
+
+    final int status = HttpStatus.INTERNAL_SERVER_ERROR.value();
+    final ErrorResponse response = ErrorResponse.of(status, ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  /**
+   * 비즈니스 로직에서 발생하는 예외 처리
+   */
+  @ExceptionHandler(BusinessException.class)
+  protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+    log.info("Handle BusinessException", e);
+
+    final ErrorCode errorCode = e.getErrorCode();
+    final int status = HttpStatus.BAD_GATEWAY.value();
+    final ErrorResponse response = ErrorResponse.of(status, errorCode);
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
+  }
+
+  /**
+   * 중복 예외 (409 CONFLICT)
+   */
+  @ExceptionHandler(DuplicateException.class)
+  protected ResponseEntity<ErrorResponse> handleDuplicationException(final DuplicateException e) {
+    log.info("Handle DuplicationException", e);
+
+    final ErrorCode errorCode = e.getErrorCode();
+    final String value = e.getValue();
+    final int status = HttpStatus.CONFLICT.value();
+    final ErrorResponse response = (value != null)
+        ? ErrorResponse.of(status, errorCode, value)
+        : ErrorResponse.of(status, errorCode);
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
+  }
+
+  /**
+   * 리소스를 찾을 수 없을 때 (404 NOT FOUND)
+   */
+  @ExceptionHandler(NotFoundException.class)
+  protected ResponseEntity<ErrorResponse> handleNotFoundException(final NotFoundException e) {
+    log.info("Handle NotFoundException", e);
+
+    final int status = HttpStatus.NOT_FOUND.value();
+    final ErrorResponse response = ErrorResponse.of(status, e.getErrorCode());
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
+  }
+
+  /**
+   * 인증 오류 (401 UNAUTHORIZED)
+   */
+  @ExceptionHandler(UnauthorizedException.class)
+  protected ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
+    log.info("Handle UnauthorizedException", e);
+
+    final int status = HttpStatus.UNAUTHORIZED.value();
+    final ErrorResponse response = ErrorResponse.of(status, e.getErrorCode());
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
+  }
+
+  /**
+   * 권한이 없는 사용자가 접근하려고 할 때 (403 FORBIDDEN)
+   */
+  @ExceptionHandler(ForbiddenException.class)
+  protected ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+    log.info("Handle ForbiddenException", e);
+
+    final int status = HttpStatus.FORBIDDEN.value();
+    final ErrorResponse response = ErrorResponse.of(status, e.getErrorCode());
+
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(MethodArgumentNotValidException.class)
   protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
-      MethodArgumentNotValidException e) {
+      final MethodArgumentNotValidException e) {
     log.info("Handle MethodArgumentNotValidException", e);
 
     final int status = HttpStatus.BAD_REQUEST.value();
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
-      MethodArgumentTypeMismatchException e) {
+      final MethodArgumentTypeMismatchException e) {
     log.info("Handle MethodArgumentTypeMismatchException", e);
 
     final int status = HttpStatus.BAD_REQUEST.value();
@@ -54,7 +54,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
   protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
-      HttpRequestMethodNotSupportedException e) {
+      final HttpRequestMethodNotSupportedException e) {
     log.info("Handle HttpRequestMethodNotSupportedException", e);
 
     final int status = HttpStatus.METHOD_NOT_ALLOWED.value();
@@ -68,21 +68,20 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpMessageNotReadableException.class)
   protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
-      HttpMessageNotReadableException e) {
+      final HttpMessageNotReadableException e) {
     log.info("Handle HttpMessageNotReadableException", e);
 
     final int status = HttpStatus.BAD_REQUEST.value();
     final ErrorResponse response = ErrorResponse.of(status, ErrorCode.INVALID_TYPE_VALUE);
 
-    return new ResponseEntity<>(response,
-        HttpStatus.valueOf(status));
+    return new ResponseEntity<>(response, HttpStatus.valueOf(status));
   }
 
   /**
    * 서버에서 발생하는 모든 예상치 못한 예외 처리
    */
   @ExceptionHandler(Exception.class)
-  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+  protected ResponseEntity<ErrorResponse> handleException(final Exception e) {
     log.error("Handle Exception", e);
 
     final int status = HttpStatus.INTERNAL_SERVER_ERROR.value();
@@ -139,7 +138,7 @@ public class GlobalExceptionHandler {
    * 인증 오류 (401 UNAUTHORIZED)
    */
   @ExceptionHandler(UnauthorizedException.class)
-  protected ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
+  protected ResponseEntity<ErrorResponse> handleUnauthorizedException(final UnauthorizedException e) {
     log.info("Handle UnauthorizedException", e);
 
     final int status = HttpStatus.UNAUTHORIZED.value();
@@ -152,7 +151,7 @@ public class GlobalExceptionHandler {
    * 권한이 없는 사용자가 접근하려고 할 때 (403 FORBIDDEN)
    */
   @ExceptionHandler(ForbiddenException.class)
-  protected ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+  protected ResponseEntity<ErrorResponse> handleForbiddenException(final ForbiddenException e) {
     log.info("Handle ForbiddenException", e);
 
     final int status = HttpStatus.FORBIDDEN.value();

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/BusinessException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.bookmate.bookmate.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public BusinessException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    // 성능 최적화를 위해 스택 트레이스를 채우지 않음
+    return this;
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/BusinessException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/BusinessException.java
@@ -7,7 +7,7 @@ public class BusinessException extends RuntimeException {
 
   private final ErrorCode errorCode;
 
-  public BusinessException(String message, ErrorCode errorCode) {
+  public BusinessException(final String message, final ErrorCode errorCode) {
     super(message);
     this.errorCode = errorCode;
   }

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/DuplicateException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/DuplicateException.java
@@ -1,0 +1,19 @@
+package com.bookmate.bookmate.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateException extends BusinessException {
+
+  private String value;
+
+  public DuplicateException(String value) {
+    this(value, ErrorCode.DUPLICATE);
+    this.value = value;
+  }
+
+  public DuplicateException(String value, ErrorCode errorCode) {
+    super(value, errorCode);
+    this.value = value;
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/DuplicateException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/DuplicateException.java
@@ -5,14 +5,13 @@ import lombok.Getter;
 @Getter
 public class DuplicateException extends BusinessException {
 
-  private String value;
+  private final String value;
 
-  public DuplicateException(String value) {
+  public DuplicateException(final String value) {
     this(value, ErrorCode.DUPLICATE);
-    this.value = value;
   }
 
-  public DuplicateException(String value, ErrorCode errorCode) {
+  public DuplicateException(final String value, final ErrorCode errorCode) {
     super(value, errorCode);
     this.value = value;
   }

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.bookmate.bookmate.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+  // Common
+  INVALID_INPUT_VALUE("C-001", "Invalid Input Value"),
+  METHOD_NOT_ALLOWED("C-002", "Method Not Allowed"),
+  INTERNAL_SERVER_ERROR("C-003", "Server Error"),
+  INVALID_TYPE_VALUE("C-004", "Invalid Type Value"),
+  HANDLE_ACCESS_DENIED("C-005", "Access is Denied"),
+
+  // Business
+  DUPLICATE("B-001", "Duplicate Value"),
+  NOT_FOUND("B-002", "Entity Not Found"),
+
+  // User
+  EMAIL_DUPLICATE("U-001", "Duplicate Email Address"),
+  NICKNAME_DUPLICATE("U-002", "Duplicate Nickname"),
+  WRONG_EMAIL_OR_PASSWORD("U-003", "Wrong Email or Password"),
+  USER_NOT_FOUND("U-004", "User Not Found"),
+  USER_DEACTIVATED("U-005", "User has been deactivated"),
+  ACCESS_TOKEN_NOT_EXPIRED_YET("U-006", "AccessToken is not expired yet"),
+  INVALID_REFRESH_TOKEN("U-007", "Invalid Refresh Token"),
+  REFRESH_TOKEN_MISMATCH("U-008", "Refresh Token mismatch. Re-login required");
+
+  private final String code;
+  private final String message;
+
+  ErrorCode(final String code, final String message) {
+    this.code = code;
+    this.message = message;
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/ForbiddenException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package com.bookmate.bookmate.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ForbiddenException extends BusinessException {
+
+  public ForbiddenException() {
+    super("Forbidden", ErrorCode.HANDLE_ACCESS_DENIED);
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/NotFoundException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/NotFoundException.java
@@ -5,14 +5,13 @@ import lombok.Getter;
 @Getter
 public class NotFoundException extends BusinessException {
 
-  private String value;
+  private final String value;
 
-  public NotFoundException(String value) {
+  public NotFoundException(final String value) {
     this(value, ErrorCode.NOT_FOUND);
-    this.value = value;
   }
 
-  public NotFoundException(String value, ErrorCode errorCode) {
+  public NotFoundException(final String value, final ErrorCode errorCode) {
     super(value, errorCode);
     this.value = value;
   }

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/NotFoundException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/NotFoundException.java
@@ -1,0 +1,19 @@
+package com.bookmate.bookmate.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends BusinessException {
+
+  private String value;
+
+  public NotFoundException(String value) {
+    this(value, ErrorCode.NOT_FOUND);
+    this.value = value;
+  }
+
+  public NotFoundException(String value, ErrorCode errorCode) {
+    super(value, errorCode);
+    this.value = value;
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/UnauthorizedException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/UnauthorizedException.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 @Getter
 public class UnauthorizedException extends BusinessException {
 
-  private String value;
-
   public UnauthorizedException() {
     super("Unauthorized", ErrorCode.HANDLE_ACCESS_DENIED);
   }

--- a/src/main/java/com/bookmate/bookmate/common/error/exception/UnauthorizedException.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/UnauthorizedException.java
@@ -1,0 +1,13 @@
+package com.bookmate.bookmate.common.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedException extends BusinessException {
+
+  private String value;
+
+  public UnauthorizedException() {
+    super("Unauthorized", ErrorCode.HANDLE_ACCESS_DENIED);
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/user/exception/EmailDuplicateException.java
+++ b/src/main/java/com/bookmate/bookmate/user/exception/EmailDuplicateException.java
@@ -1,0 +1,11 @@
+package com.bookmate.bookmate.user.exception;
+
+import com.bookmate.bookmate.common.error.exception.DuplicateException;
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+
+public class EmailDuplicateException extends DuplicateException {
+
+  public EmailDuplicateException(final String email) {
+    super(email, ErrorCode.EMAIL_DUPLICATE);
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/user/exception/NicknameDuplicateException.java
+++ b/src/main/java/com/bookmate/bookmate/user/exception/NicknameDuplicateException.java
@@ -1,0 +1,11 @@
+package com.bookmate.bookmate.user.exception;
+
+import com.bookmate.bookmate.common.error.exception.DuplicateException;
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+
+public class NicknameDuplicateException extends DuplicateException {
+
+  public NicknameDuplicateException(final String nickname) {
+    super(nickname, ErrorCode.NICKNAME_DUPLICATE);
+  }
+}

--- a/src/test/java/com/bookmate/bookmate/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bookmate/bookmate/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,70 @@
+package com.bookmate.bookmate.exception;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TestExceptionController.class)
+public class GlobalExceptionHandlerTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("409 CONFLICT - DuplicateException 핸들링 테스트")
+  @WithMockUser
+  void handleDuplicateException() throws Exception {
+    mockMvc.perform(get("/test-exception/duplicate"))
+        .andExpect(status().isConflict()) // 409 상태 코드 확인
+        .andExpect(jsonPath("$.code").value(ErrorCode.DUPLICATE.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.DUPLICATE.getMessage()));
+  }
+
+  @Test
+  @DisplayName("404 NOT FOUND - NotFoundException 핸들링 테스트")
+  @WithMockUser
+  void handleNotFoundException() throws Exception {
+    mockMvc.perform(get("/test-exception/not-found"))
+        .andExpect(status().isNotFound()) // 404 상태 코드 확인
+        .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOUND.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOUND.getMessage()));
+  }
+
+  @Test
+  @DisplayName("401 UNAUTHORIZED - UnauthorizedException 핸들링 테스트")
+  @WithMockUser
+  void handleUnauthorizedException() throws Exception {
+    mockMvc.perform(get("/test-exception/unauthorized"))
+        .andExpect(status().isUnauthorized()) // 401 상태 코드 확인
+        .andExpect(jsonPath("$.code").value(ErrorCode.HANDLE_ACCESS_DENIED.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.HANDLE_ACCESS_DENIED.getMessage()));
+  }
+
+  @Test
+  @DisplayName("403 FORBIDDEN - ForbiddenException 핸들링 테스트")
+  @WithMockUser
+  void handleForbiddenException() throws Exception {
+    mockMvc.perform(get("/test-exception/forbidden"))
+        .andExpect(status().isForbidden()) // 403 상태 코드 확인
+        .andExpect(jsonPath("$.code").value(ErrorCode.HANDLE_ACCESS_DENIED.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.HANDLE_ACCESS_DENIED.getMessage()));
+  }
+
+  @Test
+  @DisplayName("500 INTERNAL SERVER ERROR - 서버 오류 핸들링 테스트")
+  @WithMockUser
+  void handleInternalServerError() throws Exception {
+    mockMvc.perform(get("/test-exception/server-error"))
+        .andExpect(status().isInternalServerError()) // 500 상태 코드 확인
+        .andExpect(jsonPath("$.code").value(ErrorCode.INTERNAL_SERVER_ERROR.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+  }
+
+}

--- a/src/test/java/com/bookmate/bookmate/exception/TestExceptionController.java
+++ b/src/test/java/com/bookmate/bookmate/exception/TestExceptionController.java
@@ -1,0 +1,39 @@
+package com.bookmate.bookmate.exception;
+
+import com.bookmate.bookmate.common.error.exception.DuplicateException;
+import com.bookmate.bookmate.common.error.exception.ForbiddenException;
+import com.bookmate.bookmate.common.error.exception.NotFoundException;
+import com.bookmate.bookmate.common.error.exception.UnauthorizedException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test-exception")
+public class TestExceptionController {
+
+  @GetMapping("/duplicate")
+  public void throwDuplicateException() {
+    throw new DuplicateException("Duplicate test value");
+  }
+
+  @GetMapping("/not-found")
+  public void throwNotFoundException() {
+    throw new NotFoundException("Entity not found");
+  }
+
+  @GetMapping("/unauthorized")
+  public void throwUnauthorizedException() {
+    throw new UnauthorizedException();
+  }
+
+  @GetMapping("/forbidden")
+  public void throwForbiddenException() {
+    throw new ForbiddenException();
+  }
+
+  @GetMapping("/server-error")
+  public void throwServerErrorException() {
+    throw new RuntimeException("Unexpected server error");
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#3 

## 📝 작업 내용
- 커스텀 예외 처리 로직 추가
  - RuntimeException을 상속한 최상위의 BusinessException으로  공통적으로 사용할 수 있는 BaseException을 정의하고, 상황별 예외 클래스를 만들어 확장하는 방식을 사용했습니다.
  - DuplicateException, NotFoundException 등의 중간 계층에 BusinessException를 상속해 구현했습니다.
  - GlobalExceptionHandler에서 BusinessException 외에도 예외를 전역적으로 처리하도록 했습니다. (세부적으로 예외별로 다른 상태 코드가 필요하다면 GlobalExceptionHandler에 추가, 추가하지 않으면 BusinessException 상태코드로 통합적으로 처리됨)
  - ErrorCode enum 추가 및 예외 코드 정의, User 관련 예외들을 상세하게 추가하여 user.exception 패키지에서 활용 가능(UserNotFoundException → NotFoundException → BusinessException 구조로 예외 발생)
  - 아래와 같은 에러 응답이 반환됩니다.
```
{ "status": 409,
  "code": "U-001",
  "message": "Duplicate Email Address"
  "values": ["eunli@gmail.com"] }
```
- 아래 블로그 참고해서 작성하였습니다.
  - https://blog.dukcode.org/spring/spring-custom-exception-and-exception-strategy/

### 리뷰 요구사항(선택)

### 테스트
- [ ] API 테스트
- [x] 테스트 코드 작성
