### PR TITLE
독서모임 관련 기능 구현

### DIFF
--- a/src/main/java/com/bookmate/bookmate/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/ErrorCode.java
@@ -40,6 +40,20 @@ public enum ErrorCode {
   POST_NOT_FOUND("P-001", "Post Not Found"),
   POST_UPDATE_DENIED("P-002", "You do not have permission to update this post"),
   POST_DELETE_DENIED("P-003", "You do not have permission to delete this post"),
+
+  // ReadingClub
+  READING_CLUB_NOT_FOUND("RC-001", "Reading Club Not Found"),
+  READING_CLUB_UPDATE_DENIED("RC-002", "You do not have permission to update this post"),
+  READING_CLUB_DELETE_DENIED("RC-003", "You do not have permission to delete this post"),
+  READING_CLUB_DUPLICATE_JOIN("RC-004", "Duplicate join"),
+  READING_CLUB_NOT_JOINED("RC-005", "ReadingClub not joined"),
+  READING_CLUB_FULL("RC-006", "ReadingClub full"),
+  READING_CLUB_INVALID_STATUS("RC-007", "ReadingClub invalid status"),
+
+  // Chat
+  CHAT_ROOM_NOT_FOUND("CH-001", "채팅방을 찾을 수 없습니다."),
+  MESSAGE_NOT_FOUND("CH-002", "메시지를 찾을 수 없습니다."),
+  PARTICIPANT_NOT_FOUND("CH-003", "채팅 참여자를 찾을 수 없습니다."),
   ;
 
   private final String code;

--- a/src/main/java/com/bookmate/bookmate/readingclub/controller/ReadingClubController.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/controller/ReadingClubController.java
@@ -1,0 +1,181 @@
+package com.bookmate.bookmate.readingclub.controller;
+
+import com.bookmate.bookmate.common.security.CustomUserDetails;
+import com.bookmate.bookmate.readingclub.dto.request.ReadingClubRequestDto;
+import com.bookmate.bookmate.readingclub.dto.response.ReadingClubResponseDto;
+import com.bookmate.bookmate.readingclub.dto.response.ReadingClubUserResponseDto;
+import com.bookmate.bookmate.readingclub.entity.enums.ReadingClubUserStatus;
+import com.bookmate.bookmate.readingclub.service.ReadingClubJoinService;
+import com.bookmate.bookmate.readingclub.service.ReadingClubService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reading-clubs")
+@RequiredArgsConstructor
+public class ReadingClubController {
+
+  private final ReadingClubService readingClubService;
+  private final ReadingClubJoinService readingClubJoinService;
+
+  /**
+   * 독서모임 생성
+   */
+  @PostMapping
+  public ResponseEntity<ReadingClubResponseDto> createReadingClub(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody @Valid ReadingClubRequestDto dto
+  ) {
+    Long hostUserId = userDetails.getUser().getId();
+    ReadingClubResponseDto response = readingClubService.createReadingClub(hostUserId, dto);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 독서모임 수정
+   */
+  @PatchMapping("/{clubId}")
+  public ResponseEntity<ReadingClubResponseDto> updateReadingClub(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long clubId,
+      @RequestBody @Valid ReadingClubRequestDto dto
+  ) {
+    Long hostUserId = userDetails.getUser().getId();
+    ReadingClubResponseDto response = readingClubService.updateReadingClub(hostUserId, clubId, dto);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 독서모임 삭제
+   */
+  @DeleteMapping("/{clubId}")
+  public ResponseEntity<Void> deleteReadingClub(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long clubId
+  ) {
+    Long hostUserId = userDetails.getUser().getId();
+    readingClubService.deleteReadingClub(hostUserId, clubId);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 특정 유저가 가입한 독서모임 목록 조회 (페이징)
+   */
+  @GetMapping("/user/{userId}")
+  public ResponseEntity<Page<ReadingClubResponseDto>> getReadingClubsByUser(
+      @PathVariable Long userId,
+      Pageable pageable
+  ) {
+    return ResponseEntity.ok(readingClubService.getReadingClubsByUser(userId, pageable));
+  }
+
+  /**
+   * 전체 독서모임 목록 조회  (페이징)
+   */
+  @GetMapping
+  public ResponseEntity<Page<ReadingClubResponseDto>> getAllReadingClubs(Pageable pageable) {
+    return ResponseEntity.ok(readingClubService.getAllReadingClubs(pageable));
+  }
+
+  /**
+   * 특정 독서모임 조회
+   */
+  @GetMapping("/{clubId}")
+  public ResponseEntity<ReadingClubResponseDto> getReadingClub(@PathVariable Long clubId) {
+    return ResponseEntity.ok(readingClubService.getReadingClub(clubId));
+  }
+
+  /**
+   * 특정 모임의 참여자 목록(ACCEPTED)
+   */
+  @GetMapping("/{clubId}/accepted-members")
+  public ResponseEntity<Page<ReadingClubUserResponseDto>> getAcceptedMembers(
+      @PathVariable Long clubId,
+      Pageable pageable
+  ) {
+    Page<ReadingClubUserResponseDto> page = readingClubService.getReadingClubUsersByStatus(
+        clubId, ReadingClubUserStatus.ACCEPTED, pageable);
+    return ResponseEntity.ok(page);
+  }
+
+  /**
+   * 특정 모임의 신청자 목록(PENDING)
+   */
+  @GetMapping("/{clubId}/pending-members")
+  public ResponseEntity<Page<ReadingClubUserResponseDto>> getPendingMembers(
+      @PathVariable Long clubId,
+      Pageable pageable
+  ) {
+    Page<ReadingClubUserResponseDto> page = readingClubService.getReadingClubUsersByStatus(
+        clubId, ReadingClubUserStatus.PENDING, pageable);
+    return ResponseEntity.ok(page);
+  }
+
+  /**
+   * [사용자] 독서모임 가입 신청
+   */
+  @PostMapping("/{clubId}/apply")
+  public ResponseEntity<Void> applyForReadingClub(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long clubId
+  ) {
+    Long userId = userDetails.getUser().getId();
+    readingClubJoinService.applyForReadingClub(userId, clubId);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * [모임장] 독서모임 가입 승인
+   * @param targetUserId 승인 대상 사용자
+   */
+  @PatchMapping("/{clubId}/accept/{targetUserId}")
+  public ResponseEntity<Void> acceptUser(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long clubId,
+      @PathVariable Long targetUserId
+  ) {
+    Long hostUserId = userDetails.getUser().getId();
+    readingClubJoinService.acceptUser(hostUserId, clubId, targetUserId);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * [모임장] 가입 거절
+   * @param targetUserId 거절 대상 사용자
+   */
+  @PatchMapping("/{clubId}/reject/{targetUserId}")
+  public ResponseEntity<Void> rejectUser(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long clubId,
+      @PathVariable Long targetUserId
+  ) {
+    Long hostUserId = userDetails.getUser().getId();
+    readingClubJoinService.rejectUser(hostUserId, clubId, targetUserId);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * [사용자] 독서모임 탈퇴
+   */
+  @DeleteMapping("/{clubId}/leave")
+  public ResponseEntity<Void> leaveReadingClub(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long clubId
+  ) {
+    Long userId = userDetails.getUser().getId();
+    readingClubJoinService.leaveReadingClub(userId, clubId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/dto/request/ReadingClubRequestDto.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/dto/request/ReadingClubRequestDto.java
@@ -1,0 +1,32 @@
+package com.bookmate.bookmate.readingclub.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 독서모임 생성/수정 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReadingClubRequestDto {
+
+  @NotBlank(message = "독서모임 제목을 입력하세요.")
+  @Size(min = 2, max = 50, message = "독서모임 제목은 2~50자 이내여야 합니다.")
+  private String title;
+
+  @NotBlank(message = "독서모임 설명을 입력하세요.")
+  @Size(min = 10, max = 500, message = "독서모임 설명은 10~500자 이내여야 합니다.")
+  private String description;
+
+  @Min(value = 1, message = "최소 참가 인원은 1명 이상이어야 합니다.")
+  @Max(value = 30, message = "최대 참가 인원은 30명 이하이어야 합니다.")
+  private int maxParticipants;
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/dto/response/ReadingClubResponseDto.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/dto/response/ReadingClubResponseDto.java
@@ -1,0 +1,34 @@
+package com.bookmate.bookmate.readingclub.dto.response;
+
+import com.bookmate.bookmate.readingclub.entity.ReadingClub;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 독서모임 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReadingClubResponseDto {
+  private Long id;
+  private String title;
+  private String description;
+  private int maxParticipants;
+  private Long hostId;
+  private String hostNickname;
+
+  public static ReadingClubResponseDto fromEntity(ReadingClub readingClub) {
+    return ReadingClubResponseDto.builder()
+        .id(readingClub.getId())
+        .title(readingClub.getTitle())
+        .description(readingClub.getDescription())
+        .maxParticipants(readingClub.getMaxParticipants())
+        .hostId(readingClub.getHost().getId())
+        .hostNickname(readingClub.getHost().getNickname())
+        .build();
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/dto/response/ReadingClubUserResponseDto.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/dto/response/ReadingClubUserResponseDto.java
@@ -1,0 +1,29 @@
+package com.bookmate.bookmate.readingclub.dto.response;
+
+import com.bookmate.bookmate.readingclub.entity.ReadingClubUser;
+import com.bookmate.bookmate.readingclub.entity.enums.ReadingClubUserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 특정 모임에 가입/신청한 사용자 응답 DTO
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReadingClubUserResponseDto {
+  private Long userId;
+  private String nickname;
+  private ReadingClubUserStatus status;
+
+  public static ReadingClubUserResponseDto fromEntity(ReadingClubUser rcu) {
+    return ReadingClubUserResponseDto.builder()
+        .userId(rcu.getUser().getId())
+        .nickname(rcu.getUser().getNickname())
+        .status(rcu.getStatus())
+        .build();
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/entity/ReadingClub.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/entity/ReadingClub.java
@@ -1,0 +1,64 @@
+package com.bookmate.bookmate.readingclub.entity;
+
+import com.bookmate.bookmate.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "reading_club")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@DynamicUpdate
+@EntityListeners(AuditingEntityListener.class)
+public class ReadingClub {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User host;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  private int maxParticipants;
+
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  public void updateReadingClub(String title, String description, int maxParticipants) {
+    if (title != null) this.title = title;
+    if (description != null) this.description = description;
+    if (maxParticipants > 0) this.maxParticipants = maxParticipants;
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/entity/ReadingClubUser.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/entity/ReadingClubUser.java
@@ -1,0 +1,63 @@
+package com.bookmate.bookmate.readingclub.entity;
+
+import com.bookmate.bookmate.readingclub.entity.enums.ReadingClubUserStatus;
+import com.bookmate.bookmate.user.entity.User;
+import com.bookmate.bookmate.user.entity.enums.RoleType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "reading_club_user")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class ReadingClubUser {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "reading_club_id", nullable = false)
+  private ReadingClub readingClub;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ReadingClubUserStatus status = ReadingClubUserStatus.PENDING;
+
+  @CreatedDate
+  @Column(name = "joined_at", updatable = false)
+  private LocalDateTime joinedAt;
+
+  public void accept() {
+    this.status = ReadingClubUserStatus.ACCEPTED;
+  }
+
+  public void reject() {
+    this.status = ReadingClubUserStatus.REJECTED;
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/entity/enums/ReadingClubUserStatus.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/entity/enums/ReadingClubUserStatus.java
@@ -1,0 +1,5 @@
+package com.bookmate.bookmate.readingclub.entity.enums;
+
+public enum ReadingClubUserStatus {
+  PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/exception/ReadingClubForbiddenException.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/exception/ReadingClubForbiddenException.java
@@ -1,0 +1,11 @@
+package com.bookmate.bookmate.readingclub.exception;
+
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+import com.bookmate.bookmate.common.error.exception.ForbiddenException;
+
+public class ReadingClubForbiddenException extends ForbiddenException {
+
+  public ReadingClubForbiddenException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/exception/ReadingClubFullException.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/exception/ReadingClubFullException.java
@@ -1,0 +1,11 @@
+package com.bookmate.bookmate.readingclub.exception;
+
+import com.bookmate.bookmate.common.error.exception.BusinessException;
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+
+public class ReadingClubFullException extends BusinessException {
+
+  public ReadingClubFullException() {
+    super(ErrorCode.READING_CLUB_FULL);
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/exception/ReadingClubNotFoundException.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/exception/ReadingClubNotFoundException.java
@@ -1,0 +1,11 @@
+package com.bookmate.bookmate.readingclub.exception;
+
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+import com.bookmate.bookmate.common.error.exception.NotFoundException;
+
+public class ReadingClubNotFoundException extends NotFoundException {
+
+  public ReadingClubNotFoundException(final Long id) {
+    super(id, ErrorCode.READING_CLUB_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/repository/ReadingClubRepository.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/repository/ReadingClubRepository.java
@@ -1,0 +1,12 @@
+package com.bookmate.bookmate.readingclub.repository;
+
+import com.bookmate.bookmate.readingclub.entity.ReadingClub;
+import com.bookmate.bookmate.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReadingClubRepository extends JpaRepository<ReadingClub, Long> {
+  Optional<ReadingClub> findByIdAndHost(Long id, User host);
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/repository/ReadingClubUserRepository.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/repository/ReadingClubUserRepository.java
@@ -1,0 +1,40 @@
+package com.bookmate.bookmate.readingclub.repository;
+
+import com.bookmate.bookmate.readingclub.entity.ReadingClub;
+import com.bookmate.bookmate.readingclub.entity.ReadingClubUser;
+import com.bookmate.bookmate.readingclub.entity.enums.ReadingClubUserStatus;
+import com.bookmate.bookmate.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReadingClubUserRepository extends JpaRepository<ReadingClubUser, Long> {
+
+  // 모임 가입자 or 신청자 수 조회
+  @Query("SELECT COUNT(rcu) FROM ReadingClubUser rcu WHERE rcu.readingClub = :readingClub AND rcu.status = :status")
+  long countByReadingClubAndStatus(ReadingClub readingClub, ReadingClubUserStatus status);
+
+  // 특정 유저 & 특정 모임에 대한 참가 정보 조회
+  Optional<ReadingClubUser> findByReadingClubAndUser(ReadingClub readingClub, User user);
+
+  // 특정 유저가 가입한 모든 모임 목록 조회 (페이징)
+  @Query("""
+        SELECT rcu.readingClub 
+        FROM ReadingClubUser rcu 
+        WHERE rcu.user = :user
+        """)
+  Page<ReadingClub> findReadingClubsByUser(User user, Pageable pageable);
+
+  // 특정 모임에서 상태별 유저 목록 (페이징)
+  @Query("""
+        SELECT rcu
+          FROM ReadingClubUser rcu
+         WHERE rcu.readingClub = :club
+           AND rcu.status = :status
+        """)
+  Page<ReadingClubUser> findByReadingClubAndStatus(ReadingClub club, ReadingClubUserStatus status, Pageable pageable);
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubJoinService.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubJoinService.java
@@ -1,0 +1,16 @@
+package com.bookmate.bookmate.readingclub.service;
+
+public interface ReadingClubJoinService {
+
+  // 독서모임 가입 신청
+  void applyForReadingClub(Long userId, Long readingClubId);
+
+  // 독서모임 가입 승인 (host만 가능, 정원 체크)
+  void acceptUser(Long hostUserId, Long readingClubId, Long targetUserId);
+
+  // 독서모임 가입 거절
+  void rejectUser(Long hostUserId, Long clubId, Long targetUserId);
+
+  // 독서모임 탈퇴
+  void leaveReadingClub(Long userId, Long readingClubId);
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubJoinServiceImpl.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubJoinServiceImpl.java
@@ -1,0 +1,118 @@
+package com.bookmate.bookmate.readingclub.service;
+
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+import com.bookmate.bookmate.readingclub.entity.ReadingClub;
+import com.bookmate.bookmate.readingclub.entity.ReadingClubUser;
+import com.bookmate.bookmate.readingclub.entity.enums.ReadingClubUserStatus;
+import com.bookmate.bookmate.readingclub.exception.ReadingClubFullException;
+import com.bookmate.bookmate.readingclub.exception.ReadingClubForbiddenException;
+import com.bookmate.bookmate.readingclub.exception.ReadingClubNotFoundException;
+import com.bookmate.bookmate.readingclub.repository.ReadingClubRepository;
+import com.bookmate.bookmate.readingclub.repository.ReadingClubUserRepository;
+import com.bookmate.bookmate.user.entity.User;
+import com.bookmate.bookmate.user.exception.UserNotFoundException;
+import com.bookmate.bookmate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReadingClubJoinServiceImpl implements ReadingClubJoinService {
+
+  private final ReadingClubRepository readingClubRepository;
+  private final ReadingClubUserRepository readingClubUserRepository;
+  private final UserRepository userRepository;
+
+  // 독서모임 가입 신청
+  @Override
+  public void applyForReadingClub(Long userId, Long readingClubId) {
+    User user = findUserById(userId);
+    ReadingClub club = findReadingClubById(readingClubId);
+
+    if (readingClubUserRepository.findByReadingClubAndUser(club, user).isPresent()) {
+      throw new ReadingClubForbiddenException(ErrorCode.READING_CLUB_DUPLICATE_JOIN);
+    }
+
+    long acceptedCount = readingClubUserRepository.countByReadingClubAndStatus(
+        club, ReadingClubUserStatus.ACCEPTED);
+    if (acceptedCount >= club.getMaxParticipants()) {
+      throw new ReadingClubFullException();
+    }
+
+    ReadingClubUser record = ReadingClubUser.builder()
+        .readingClub(club)
+        .user(user)
+        .build();
+    readingClubUserRepository.save(record);
+  }
+
+  // 독서모임 가입 승인 (host만 가능, 정원 체크)
+  @Override
+  public void acceptUser(Long hostUserId, Long readingClubId, Long targetUserId) {
+    ReadingClub club = findReadingClubById(readingClubId);
+    if (!club.getHost().getId().equals(hostUserId)) {
+      throw new ReadingClubForbiddenException(ErrorCode.READING_CLUB_UPDATE_DENIED);
+    }
+
+    User targetUser = findUserById(targetUserId);
+    ReadingClubUser rcu = readingClubUserRepository
+        .findByReadingClubAndUser(club, targetUser)
+        .orElseThrow(() -> new ReadingClubForbiddenException(ErrorCode.READING_CLUB_NOT_JOINED));
+
+    if (rcu.getStatus() != ReadingClubUserStatus.PENDING) {
+      throw new ReadingClubForbiddenException(ErrorCode.READING_CLUB_INVALID_STATUS);
+    }
+
+    long acceptedCount = readingClubUserRepository.countByReadingClubAndStatus(club, ReadingClubUserStatus.ACCEPTED);
+    if (acceptedCount >= club.getMaxParticipants()) {
+      throw new ReadingClubFullException();
+    }
+
+    rcu.accept();
+  }
+
+  // 독서모임 가입 거절
+  @Override
+  public void rejectUser(Long hostUserId, Long clubId, Long targetUserId) {
+    ReadingClub club = findReadingClubById(clubId);
+    if (!club.getHost().getId().equals(hostUserId)) {
+      throw new ReadingClubForbiddenException(ErrorCode.READING_CLUB_UPDATE_DENIED);
+    }
+
+    User targetUser = findUserById(targetUserId);
+
+    ReadingClubUser rcu = readingClubUserRepository
+        .findByReadingClubAndUser(club, targetUser)
+        .orElseThrow(() -> new ReadingClubForbiddenException(ErrorCode.READING_CLUB_NOT_JOINED));
+
+    if (rcu.getStatus() != ReadingClubUserStatus.PENDING) {
+      throw new ReadingClubForbiddenException(ErrorCode.READING_CLUB_INVALID_STATUS);
+    }
+
+    rcu.reject();
+  }
+
+  // 독서모임 탈퇴
+  @Override
+  public void leaveReadingClub(Long userId, Long readingClubId) {
+    User user = findUserById(userId);
+    ReadingClub club = findReadingClubById(readingClubId);
+
+    ReadingClubUser record = readingClubUserRepository.findByReadingClubAndUser(club, user)
+        .orElseThrow(() -> new ReadingClubForbiddenException(ErrorCode.READING_CLUB_NOT_JOINED));
+
+    readingClubUserRepository.delete(record);
+  }
+
+  private User findUserById(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+  }
+
+  private ReadingClub findReadingClubById(Long id) {
+    return readingClubRepository.findById(id)
+        .orElseThrow(() -> new ReadingClubNotFoundException(id));
+  }
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubService.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubService.java
@@ -1,0 +1,32 @@
+package com.bookmate.bookmate.readingclub.service;
+
+import com.bookmate.bookmate.readingclub.dto.request.ReadingClubRequestDto;
+import com.bookmate.bookmate.readingclub.dto.response.ReadingClubResponseDto;
+import com.bookmate.bookmate.readingclub.dto.response.ReadingClubUserResponseDto;
+import com.bookmate.bookmate.readingclub.entity.enums.ReadingClubUserStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReadingClubService {
+
+  // 독서모임 생성
+  ReadingClubResponseDto createReadingClub(Long hostUserId, ReadingClubRequestDto requestDto);
+
+  // 독서모임 수정
+  ReadingClubResponseDto updateReadingClub(Long hostUserId, Long readingClubId, ReadingClubRequestDto requestDto);
+
+  // 독서모임 삭제
+  void deleteReadingClub(Long hostUserId, Long readingClubId);
+
+  // 특정 유저가 가입한 독서모임 목록 조회 (페이징)
+  Page<ReadingClubResponseDto> getReadingClubsByUser(Long userId, Pageable pageable);
+
+  // 전체 독서모임 목록 조회  (페이징)
+  Page<ReadingClubResponseDto> getAllReadingClubs(Pageable pageable);
+
+  // 특정 독서모임 조회
+  ReadingClubResponseDto getReadingClub(Long readingClubId);
+
+  // 특정 독서모임 + 특정 status에 해당하는 사용자 목록 (페이징)
+  Page<ReadingClubUserResponseDto> getReadingClubUsersByStatus(Long clubId, ReadingClubUserStatus status, Pageable pageable);
+}

--- a/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubServiceImpl.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubServiceImpl.java
@@ -1,0 +1,130 @@
+package com.bookmate.bookmate.readingclub.service;
+
+import com.bookmate.bookmate.common.error.exception.ErrorCode;
+import com.bookmate.bookmate.readingclub.dto.request.ReadingClubRequestDto;
+import com.bookmate.bookmate.readingclub.dto.response.ReadingClubResponseDto;
+import com.bookmate.bookmate.readingclub.dto.response.ReadingClubUserResponseDto;
+import com.bookmate.bookmate.readingclub.entity.ReadingClub;
+import com.bookmate.bookmate.readingclub.entity.ReadingClubUser;
+import com.bookmate.bookmate.readingclub.entity.enums.ReadingClubUserStatus;
+import com.bookmate.bookmate.readingclub.exception.ReadingClubForbiddenException;
+import com.bookmate.bookmate.readingclub.exception.ReadingClubNotFoundException;
+import com.bookmate.bookmate.readingclub.repository.ReadingClubRepository;
+import com.bookmate.bookmate.readingclub.repository.ReadingClubUserRepository;
+import com.bookmate.bookmate.user.entity.User;
+import com.bookmate.bookmate.user.exception.UserNotFoundException;
+import com.bookmate.bookmate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReadingClubServiceImpl implements ReadingClubService {
+
+  private final ReadingClubRepository readingClubRepository;
+  private final ReadingClubUserRepository readingClubUserRepository;
+  private final UserRepository userRepository;
+
+  // 독서모임 생성
+  @Override
+  public ReadingClubResponseDto createReadingClub(Long hostUserId, ReadingClubRequestDto requestDto) {
+    User host = findUserById(hostUserId);
+
+    ReadingClub readingClub = ReadingClub.builder()
+        .host(host)
+        .title(requestDto.getTitle())
+        .description(requestDto.getDescription())
+        .maxParticipants(requestDto.getMaxParticipants())
+        .build();
+
+    ReadingClub saved = readingClubRepository.save(readingClub);
+
+    // 호스트 본인을 독서모임에 자동 가입
+    ReadingClubUser hostJoin = ReadingClubUser.builder()
+        .readingClub(saved)
+        .user(host)
+        .build();
+    readingClubUserRepository.save(hostJoin);
+
+    // todo: 모임 생성 후 그룹채팅방 자동 생성
+    // chatService.createGroupChatRoom(saved);
+
+    return ReadingClubResponseDto.fromEntity(saved);
+  }
+
+  // 독서모임 수정
+  @Override
+  public ReadingClubResponseDto updateReadingClub(Long hostUserId, Long readingClubId, ReadingClubRequestDto requestDto) {
+    ReadingClub club = findReadingClubById(readingClubId);
+
+    if (!club.getHost().getId().equals(hostUserId)) {
+      throw new ReadingClubForbiddenException(ErrorCode.READING_CLUB_UPDATE_DENIED);
+    }
+
+    club.updateReadingClub(requestDto.getTitle(), requestDto.getDescription(), requestDto.getMaxParticipants());
+    return ReadingClubResponseDto.fromEntity(club);
+  }
+
+  // 독서모임 삭제
+  @Override
+  public void deleteReadingClub(Long hostUserId, Long readingClubId) {
+    ReadingClub club = findReadingClubById(readingClubId);
+
+    if (!club.getHost().getId().equals(hostUserId)) {
+      throw new ReadingClubForbiddenException(ErrorCode.READING_CLUB_DELETE_DENIED);
+    }
+
+    // todo: 해당 ChatRoom 삭제
+    // charService.deleteGroupChatRoom(club);
+
+    readingClubRepository.delete(club);
+  }
+
+  // 특정 유저가 가입한 독서모임 목록 조회 (페이징)
+  @Override
+  @Transactional(readOnly = true)
+  public Page<ReadingClubResponseDto> getReadingClubsByUser(Long userId, Pageable pageable) {
+    User user = findUserById(userId);
+    return readingClubUserRepository.findReadingClubsByUser(user, pageable)
+        .map(ReadingClubResponseDto::fromEntity);
+  }
+
+  // 전체 독서모임 목록 조회  (페이징)
+  @Override
+  @Transactional(readOnly = true)
+  public Page<ReadingClubResponseDto> getAllReadingClubs(Pageable pageable) {
+    return readingClubRepository.findAll(pageable)
+        .map(ReadingClubResponseDto::fromEntity);
+  }
+
+  // 특정 독서모임 조회
+  @Override
+  @Transactional(readOnly = true)
+  public ReadingClubResponseDto getReadingClub(Long readingClubId) {
+    ReadingClub club = findReadingClubById(readingClubId);
+    return ReadingClubResponseDto.fromEntity(club);
+  }
+
+  // 특정 독서모임 + 특정 status에 해당하는 사용자 목록 (페이징)
+  @Override
+  @Transactional(readOnly = true)
+  public Page<ReadingClubUserResponseDto> getReadingClubUsersByStatus(Long clubId, ReadingClubUserStatus status, Pageable pageable) {
+    ReadingClub club = findReadingClubById(clubId);
+    return readingClubUserRepository.findByReadingClubAndStatus(club, status, pageable)
+        .map(ReadingClubUserResponseDto::fromEntity);
+  }
+
+  private User findUserById(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+  }
+
+  private ReadingClub findReadingClubById(Long id) {
+    return readingClubRepository.findById(id)
+        .orElseThrow(() -> new ReadingClubNotFoundException(id));
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#11 

## 📝 작업 내용
- 독서모임 생성/수정/삭제
- 독서모임 전체목록 조회, 특정 유저가 가입한 독서모임 목록 조회, 독서모임 상세조회, 특정 독서모임 신청or가입 사용자 목록 조회
- 독서모임 가입신청, 승인, 거절, 탈퇴

### 서비스 흐름
**(모임장)독서모임 개설/수정/삭제 → (모임장)독서모임 모집 게시글 작성 → (사용자)독서모임 신청 → (모임장)독서모임 가입/승인/거절**
- 위와 같이 진행하려고 합니다. 독서모임을 개설/삭제할 때 그룹채팅을 자동 생성/삭제하고, 가입 승인 시 그룹채팅에 초대되도록 채팅관련 기능을 작성할 예정입니다. 채팅기능 전에 독서모임 모집 게시글 관련 부분부터 진행할 예정입니다.

### 리뷰 요구사항(선택)

### 테스트
- [ ] API 테스트
- [ ] 테스트 코드 작성
