### PR TITLE
fix: reading club 삭제 시 해당 참여자들 삭제 추가, 그 외 api 테스트 하면서 수정 #11

### DIFF
--- a/src/main/java/com/bookmate/bookmate/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/bookmate/bookmate/common/error/exception/ErrorCode.java
@@ -43,8 +43,8 @@ public enum ErrorCode {
 
   // ReadingClub
   READING_CLUB_NOT_FOUND("RC-001", "Reading Club Not Found"),
-  READING_CLUB_UPDATE_DENIED("RC-002", "You do not have permission to update this post"),
-  READING_CLUB_DELETE_DENIED("RC-003", "You do not have permission to delete this post"),
+  READING_CLUB_UPDATE_DENIED("RC-002", "You do not have permission to update this reading club"),
+  READING_CLUB_DELETE_DENIED("RC-003", "You do not have permission to delete this reading club"),
   READING_CLUB_DUPLICATE_JOIN("RC-004", "Duplicate join"),
   READING_CLUB_NOT_JOINED("RC-005", "ReadingClub not joined"),
   READING_CLUB_FULL("RC-006", "ReadingClub full"),

--- a/src/main/java/com/bookmate/bookmate/readingclub/repository/ReadingClubUserRepository.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/repository/ReadingClubUserRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -37,4 +38,8 @@ public interface ReadingClubUserRepository extends JpaRepository<ReadingClubUser
            AND rcu.status = :status
         """)
   Page<ReadingClubUser> findByReadingClubAndStatus(ReadingClub club, ReadingClubUserStatus status, Pageable pageable);
+
+  @Modifying
+  @Query("DELETE FROM ReadingClubUser rcu WHERE rcu.readingClub = :readingClub")
+  void deleteByReadingClub(ReadingClub readingClub);
 }

--- a/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubJoinServiceImpl.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubJoinServiceImpl.java
@@ -44,6 +44,7 @@ public class ReadingClubJoinServiceImpl implements ReadingClubJoinService {
     ReadingClubUser record = ReadingClubUser.builder()
         .readingClub(club)
         .user(user)
+        .status(ReadingClubUserStatus.PENDING)
         .build();
     readingClubUserRepository.save(record);
   }
@@ -71,6 +72,8 @@ public class ReadingClubJoinServiceImpl implements ReadingClubJoinService {
     }
 
     rcu.accept();
+
+    // todo: 해당 독서모임 그룹채팅 초대
   }
 
   // 독서모임 가입 거절

--- a/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubServiceImpl.java
+++ b/src/main/java/com/bookmate/bookmate/readingclub/service/ReadingClubServiceImpl.java
@@ -47,6 +47,7 @@ public class ReadingClubServiceImpl implements ReadingClubService {
     ReadingClubUser hostJoin = ReadingClubUser.builder()
         .readingClub(saved)
         .user(host)
+        .status(ReadingClubUserStatus.ACCEPTED)
         .build();
     readingClubUserRepository.save(hostJoin);
 
@@ -81,6 +82,7 @@ public class ReadingClubServiceImpl implements ReadingClubService {
     // todo: 해당 ChatRoom 삭제
     // charService.deleteGroupChatRoom(club);
 
+    readingClubUserRepository.deleteByReadingClub(club);
     readingClubRepository.delete(club);
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#11 

## 📝 작업 내용
- 독서모임 삭제 시 해당 참여자들 삭제되도록 수정
- 그 외 테스트하면서 수정

### 리뷰 요구사항(선택)

### 테스트
- [x] API 테스트
- [ ] 테스트 코드 작성
